### PR TITLE
unpin pydantic

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,7 @@ source:
   sha256: 853b2038496fb8f85cad205943dede877f65ab86e856f296587885dafcef643d
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: mlflow{{ mlflow_suffix }}
@@ -70,7 +70,7 @@ outputs:
         - mlflow{{ mlflow_other }} <0a0
         # mlflow[gateway] requirements as it is auto-imported if all dependencies are met
         # See https://github.com/mlflow/mlflow/blob/045ab98cb4c08e71f0d740a0d5a033d6c69dcf8c/mlflow/__init__.py#L244-L249
-        - pydantic >=1.0,<2
+        - pydantic
         - fastapi <1
         - uvicorn-standard <1
         - watchfiles <1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -70,7 +70,7 @@ outputs:
         - mlflow{{ mlflow_other }} <0a0
         # mlflow[gateway] requirements as it is auto-imported if all dependencies are met
         # See https://github.com/mlflow/mlflow/blob/045ab98cb4c08e71f0d740a0d5a033d6c69dcf8c/mlflow/__init__.py#L244-L249
-        - pydantic
+        - pydantic >=1.0
         - fastapi <1
         - uvicorn-standard <1
         - watchfiles <1


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [X] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [X] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [X] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

Removing the pydantic requirement pinning, as MLflow AI Gateway is now compatible with both pydantic 1.x and 2.x