### PR TITLE
Add separate build for UI

### DIFF
--- a/recipe/build-mlflow.bat
+++ b/recipe/build-mlflow.bat
@@ -8,7 +8,7 @@ if [%PKG_NAME%] == [mlflow-skinny] (
 
 %PREFIX%/python.exe -m pip install . --no-deps --ignore-installed -vv
 
-if [%PKG_NAME%] == [mlflow] (
+if [%PKG_NAME%] NEQ [mlflow-ui-dbg] (
   bash -c 'rm ${PREFIX//\\\\//}/Lib/site-packages/mlflow/server/js/build/static/css/*.css.map'
   bash -c 'rm ${PREFIX//\\\\//}/Lib/site-packages/mlflow/server/js/build/static/js/*.js.map'
 )

--- a/recipe/build-mlflow.bat
+++ b/recipe/build-mlflow.bat
@@ -9,6 +9,6 @@ if [%PKG_NAME%] == [mlflow-skinny] (
 %PREFIX%/python.exe -m pip install . --no-deps --ignore-installed -vv
 
 if [%PKG_NAME%] NEQ [mlflow-ui-dbg] (
-  bash -c 'rm ${PREFIX//\\\\//}/Lib/site-packages/mlflow/server/js/build/static/css/*.css.map'
-  bash -c 'rm ${PREFIX//\\\\//}/Lib/site-packages/mlflow/server/js/build/static/js/*.js.map'
+  bash -c 'rm -f ${PREFIX//\\\\//}/Lib/site-packages/mlflow/server/js/build/static/css/*.css.map'
+  bash -c 'rm -f ${PREFIX//\\\\//}/Lib/site-packages/mlflow/server/js/build/static/js/*.js.map'
 )

--- a/recipe/build-mlflow.sh
+++ b/recipe/build-mlflow.sh
@@ -9,7 +9,7 @@ if [[ "${PKG_NAME}" == "mlflow-skinny" ]]; then
 fi
 
 $PREFIX/bin/python -m pip install . --no-deps --ignore-installed --no-build-isolation -vv
-if [[ "$PKG_NAME" == "mlflow" ]]; then
+if [[ "$PKG_NAME" != "mlflow-ui-dbg" ]]; then
   rm $PREFIX/lib/python${PY_VER}/site-packages/mlflow/server/js/build/static/css/*.css.map
   rm $PREFIX/lib/python${PY_VER}/site-packages/mlflow/server/js/build/static/js/*.js.map
 fi

--- a/recipe/build-mlflow.sh
+++ b/recipe/build-mlflow.sh
@@ -10,6 +10,6 @@ fi
 
 $PREFIX/bin/python -m pip install . --no-deps --ignore-installed --no-build-isolation -vv
 if [[ "$PKG_NAME" != "mlflow-ui-dbg" ]]; then
-  rm $PREFIX/lib/python${PY_VER}/site-packages/mlflow/server/js/build/static/css/*.css.map
-  rm $PREFIX/lib/python${PY_VER}/site-packages/mlflow/server/js/build/static/js/*.js.map
+  rm -f $PREFIX/lib/python${PY_VER}/site-packages/mlflow/server/js/build/static/css/*.css.map
+  rm -f $PREFIX/lib/python${PY_VER}/site-packages/mlflow/server/js/build/static/js/*.js.map
 fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0001-Don-t-install-pylint_plugins.patch
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - name: mlflow-skinny
@@ -80,9 +80,9 @@ outputs:
         - pip
         - python
         - setuptools
-        - {{ pin_subpackage('mlflow-skinny', exact=True) }}
+        - {{ pin_subpackage('mlflow-ui', exact=True) }}
       run:
-        - {{ pin_subpackage('mlflow-skinny', exact=True) }}
+        - {{ pin_subpackage('mlflow-ui', exact=True) }}
         - alembic <2,!=1.10
         - docker-py >=4.0.0,<8
         - flask <4
@@ -192,6 +192,32 @@ outputs:
     test:
       imports:
         - mlflow.gateway
+
+
+  - name: mlflow-ui
+    version: {{ version }}
+    requirements:
+      build:
+        - python                                 # [build_platform != target_platform]
+        - cross-python_{{ target_platform }}     # [build_platform != target_platform]
+      host:
+        - python
+        - pip
+        - setuptools
+        - {{ pin_subpackage('mlflow-skinny', exact=True) }}
+      run:
+        - python
+        - {{ pin_subpackage('mlflow-skinny', exact=True) }}
+        - flask <4
+        - gunicorn <22  # [not win]
+        - waitress <3  # [win]
+        - querystring_parser <2
+    script: build-mlflow.bat  # [win]
+    script: build-mlflow.sh  # [unix]
+    test:
+      commands:
+        - mlflow --help
+
 
 about:
   home: https://mlflow.org/


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Now that `mlflow-skinny` and `mlflow` can be installed into the same environment (#163), I'm going one step further and putting all the Javascript into a separate `mlflow-ui` package. This is meant for users who want a lightweight package to run the UI (and nothing else).

- `mlflow-ui` depends on `mlflow-skinny`
- `mlflow` depends on `mlflow-ui`

Contents of `mlflow-ui`:

```
tree -L 9 
.
├── info
│   ├── about.json
│   ├── files
│   ├── git
│   ├── hash_input.json
│   ├── index.json
│   ├── licenses
│   │   └── LICENSE
│   ├── paths.json
│   ├── recipe
│   │   ├── build-mlflow.sh
│   │   ├── conda_build_config.yaml
│   │   ├── meta.yaml
│   │   └── parent
│   │       ├── 0001-Don-t-install-pylint_plugins.patch
│   │       ├── LICENSE
│   │       ├── README_SKINNY.rst
│   │       ├── build-mlflow.bat
│   │       ├── build-mlflow.sh
│   │       ├── meta.yaml
│   │       ├── noop.bat
│   │       └── noop.sh
│   └── test
│       └── run_test.sh
└── lib
    └── python3.10
        └── site-packages
            ├── mlflow
            │   ├── models
            │   │   └── container
            │   │       └── scoring_server
            │   │           └── nginx.conf
            │   └── server
            │       └── js
            │           └── build
            │               ├── asset-manifest.json
            │               ├── favicon.ico
            │               ├── index.html
            │               ├── manifest.json
            │               ├── pdf.worker.js
            │               └── static
            │                   ├── css  # this directory contains a bunch of files
            │                   ├── js   # this directory contains a bunch of files
            │                   └── media   # this directory contains a bunch of files
            └── mlflow-2.10.2.dist-info
                ├── INSTALLER
                ├── LICENSE.txt
                ├── METADATA
                ├── RECORD
                ├── REQUESTED
                ├── WHEEL
                ├── direct_url.json
                ├── entry_points.txt
                └── top_level.txt

21 directories, 34 files
```