### PR TITLE
Update package version constraints in meta.yaml

### DIFF
--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -1,0 +1,15 @@
+# This file was generated automatically from conda-smithy. To update this configuration,
+# update the conda-forge.yml and/or the recipe/meta.yaml.
+# -*- mode: yaml -*-
+
+name: Build conda package
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Disabled build
+    runs-on: ubuntu-slim
+    if: false
+    steps:
+    - run: exit 0

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -20,6 +20,7 @@ export PYTHONUNBUFFERED=1
 export RECIPE_ROOT="${RECIPE_ROOT:-/home/conda/recipe_root}"
 export CI_SUPPORT="${FEEDSTOCK_ROOT}/.ci_support"
 export CONFIG_FILE="${CI_SUPPORT}/${CONFIG}.yaml"
+export RATTLER_CACHE_DIR="${FEEDSTOCK_ROOT}/build_artifacts/pkg_cache"
 
 cat >~/.condarc <<CONDARC
 

--- a/build-locally.py
+++ b/build-locally.py
@@ -28,13 +28,6 @@ def setup_environment(ns):
             os.path.dirname(__file__), "miniforge3"
         )
 
-    # The default cache location might not be writable using docker on macOS.
-    if ns.config.startswith("linux") and platform.system() == "Darwin":
-        os.environ["CONDA_FORGE_DOCKER_RUN_ARGS"] = (
-            os.environ.get("CONDA_FORGE_DOCKER_RUN_ARGS", "")
-            + " -e RATTLER_CACHE_DIR=/tmp/rattler_cache"
-        )
-
 
 def run_docker_build(ns):
     script = ".scripts/run_docker_build.sh"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0001-Build-leaner-source-maps.patch
 
 build:
-  number: 0
+  number: 1
   noarch: python
 
 outputs:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,7 +31,7 @@ outputs:
         - setuptools
       run:
         - python >={{ python_min }}
-        - cachetools <7,>=5.0.0
+        - cachetools <8,>=5.0.0
         - click <9,>=7.0
         - cloudpickle <4
         - databricks-sdk <1,>=0.20.0
@@ -41,9 +41,9 @@ outputs:
         - opentelemetry-api <3,>=1.9.0
         - opentelemetry-proto <3,>=1.9.0
         - opentelemetry-sdk <3,>=1.9.0
-        - packaging <26
+        - packaging <27
         - protobuf <7,>=3.12.0
-        - pydantic <3,>=1.10.8
+        - pydantic <3,>=2.0.0
         - python-dotenv <2,>=0.19.0
         - pyyaml <7,>=5.1
         - requests <3,>=2.17.3
@@ -84,8 +84,8 @@ outputs:
       run:
         - python >={{ python_min }}
         - {{ pin_subpackage('mlflow-ui', exact=True) }}
-        - alembic <2,!=1.10
-        - cachetools <7,>=5.0.0
+        - alembic <2,!=1.10.0
+        - cachetools <8,>=5.0.0
         - click <9,>=7.0
         - cloudpickle <4
         - cryptography <47,>=43.0.0
@@ -96,20 +96,20 @@ outputs:
         - flask-cors <7
         - gitpython <4,>=3.1.9
         - graphene <4
-        - gunicorn <24  # [not win]
-        - huey <3,>=2.5.0
+        - gunicorn <26  # [not win]
+        - huey <3,>=2.5.4
         - importlib-metadata <9,>=3.7.0,!=4.7.0
         - matplotlib-base <4
         - numpy <3
         - opentelemetry-api <3,>=1.9.0
         - opentelemetry-proto <3,>=1.9.0
         - opentelemetry-sdk <3,>=1.9.0
-        - packaging <26
+        - packaging <27
         - pandas <3
         - prometheus_flask_exporter <1
         - protobuf <7,>=3.12.0
-        - pyarrow <22,>=4.0.0
-        - pydantic <3,>=1.10.8
+        - pyarrow <24,>=4.0.0
+        - pydantic <3,>=2.0.0
         - python-dotenv <2,>=0.19.0
         - pyyaml <7,>=5.1
         - requests <3,>=2.17.3


### PR DESCRIPTION
Update min / max allowed versions of many dependencies, to reflect those found in `pyproject.toml` for the `mlflow` 3.10.1 release: ﻿

https://github.com/mlflow/mlflow/blob/branch-3.10/pyproject.toml

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please add any other relevant info below:
-->

I noticed that this was out of date because it was blocking our update to a more recent version of pyarrow, but then saw there were a number of other packages whose pins had been updated upstream, so tried to propagate those changes here.