### PR TITLE
Apply CVE-2025-0453 patch, bump build number to 1

### DIFF
--- a/recipe/CVE-2025-0453-mlflow-3.11.1.patch
+++ b/recipe/CVE-2025-0453-mlflow-3.11.1.patch
@@ -1,0 +1,21 @@
+--- a/mlflow/server/handlers.py
++++ b/mlflow/server/handlers.py
+@@ -279,7 +279,7 @@
+ from mlflow.store.jobs.abstract_store import AbstractJobStore
+ from mlflow.store.model_registry.abstract_store import AbstractStore as AbstractModelRegistryStore
+ from mlflow.store.model_registry.rest_store import RestStore as ModelRegistryRestStore
+-from mlflow.store.tracking import MAX_RESULTS_QUERY_TRACE_METRICS, SEARCH_MAX_RESULTS_DEFAULT
++from mlflow.store.tracking import MAX_RESULTS_QUERY_TRACE_METRICS, SEARCH_MAX_RESULTS_DEFAULT, SEARCH_MAX_RESULTS_THRESHOLD
+ from mlflow.store.tracking.abstract_store import AbstractStore as AbstractTrackingStore
+ from mlflow.store.tracking.databricks_rest_store import DatabricksTracingRestStore
+ from mlflow.store.workspace.abstract_store import WorkspaceNameValidator
+@@ -1710,7 +1710,8 @@
+     if request_message.HasField("run_view_type"):
+         run_view_type = ViewType.from_proto(request_message.run_view_type)
+     filter_string = request_message.filter
+-    max_results = request_message.max_results
++    max_results = request_message.max_results or SEARCH_MAX_RESULTS_DEFAULT
++    max_results = min(max_results, SEARCH_MAX_RESULTS_THRESHOLD)
+     experiment_ids = list(request_message.experiment_ids)
+ 
+     # NB: Local import to avoid circular dependency (auth imports from handlers)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,10 @@ source:
   sha256: 315ed7b95fa284c96e6581f63da0c93d1dec99271b8a8f06d4857b3ec66fd30a
   patches:
     - 0001-Build-leaner-source-maps.patch
+    - CVE-2025-0453-mlflow-3.11.1.patch
 
 build:
-  number: 0
+  number: 1
   noarch: python
 
 outputs:


### PR DESCRIPTION
Added to patch for the mentioned CVE in title.
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
