### PR TITLE
Bump protobuf pin to <8

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -3,6 +3,6 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- quay.io/condaforge/linux-anvil-x86_64:alma9
+- quay.io/condaforge/linux-anvil-x86_64:alma10
 python_min:
 - '3.10'

--- a/.github/workflows/conda-build.yml
+++ b/.github/workflows/conda-build.yml
@@ -23,7 +23,7 @@ jobs:
       matrix:
         include:
           - CONFIG: linux_64_
-            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma9
+            DOCKER_IMAGE: quay.io/condaforge/linux-anvil-x86_64:alma10
             STORE_BUILD_ARTIFACTS: False
             UPLOAD_PACKAGES: True
             build_workspace_dir: build_artifacts

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0001-Build-leaner-source-maps.patch
 
 build:
-  number: 1
+  number: 2 
   noarch: python
 
 outputs:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ outputs:
         - opentelemetry-proto <3,>=1.9.0
         - opentelemetry-sdk <3,>=1.9.0
         - packaging <27
-        - protobuf <7,>=3.12.0
+        - protobuf <8,>=3.12.0
         - pydantic <3,>=2.0.0
         - python-dotenv <2,>=0.19.0
         - pyyaml <7,>=5.1
@@ -109,7 +109,7 @@ outputs:
         - packaging <27
         - pandas <3
         - prometheus_flask_exporter <1
-        - protobuf <7,>=3.12.0
+        - protobuf <8,>=3.12.0
         - pyarrow <25,>=4.0.0
         - pydantic <3,>=2.0.0
         - python-dotenv <2,>=0.19.0


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

Align with [upstream](https://github.com/mlflow/mlflow/blob/86cd7f5a1dc25a1387ad07c87811bbc30f62951c/pyproject.toml#L53). 
When using `mlflow==3.14`, `pyarrow>=24` requires `libprotobuf>=7.35.1` (through `libarrow` → `libgoogle-cloud`) and `protobuf<7,>=3.12.0` requires `libprotobuf==6.33.5`. These two versions of libprotobuf obviously conflict
