### PR TITLE
[ci skip] removing users @BenWilson2 and @WeichenXu123

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @B-Step62 @BenWilson2 @TomeHirata @WeichenXu123 @daniellok-db @dbczumar @harupy @janjagusch @jaroslawk @serena-ruan @xhochy
+* @B-Step62 @TomeHirata @daniellok-db @dbczumar @harupy @janjagusch @jaroslawk @serena-ruan @xhochy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -276,8 +276,6 @@ extra:
     - daniellok-db
     - B-Step62
     - serena-ruan
-    - BenWilson2
-    - WeichenXu123
     - harupy
     - dbczumar
     - jaroslawk


### PR DESCRIPTION
Removes `BenWilson2` and `WeichenXu123` from `recipe-maintainers`, as they are no longer working on MLflow.

Updates both `recipe/meta.yaml` and `.github/CODEOWNERS`. No build changes, so `[ci skip]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)